### PR TITLE
Process general data tidy

### DIFF
--- a/scraper.js
+++ b/scraper.js
@@ -1,9 +1,13 @@
-import { processGeneralData, getNameValue, getYearValue } from "./utils/scraper/processGeneralData.js"
+import {
+  processGeneralData,
+  getNameValue,
+  getYearValue,
+} from "./utils/scraper/processGeneralData.js"
 import processTableData from "./utils/scraper/processTableData.js"
 import insertSchoolData from "./model/school_data.js"
 
 const scraper = async pdfPath => {
-  // CORE VALUES
+  // SCHOOL NAME AND YEAR VALUES
   const schoolname = { schoolname: getNameValue(pdfPath) }
   const year = { year: getYearValue(pdfPath) }
 

--- a/scraper.js
+++ b/scraper.js
@@ -1,11 +1,19 @@
-import processGeneralData from "./utils/scraper/processGeneralData.js"
+import { processGeneralData, getNameValue, getYearValue } from "./utils/scraper/processGeneralData.js"
 import processTableData from "./utils/scraper/processTableData.js"
 import insertSchoolData from "./model/school_data.js"
 
 const scraper = async pdfPath => {
+  // CORE VALUES
+  const schoolname = { schoolname: getNameValue(pdfPath) }
+  const year = { year: getYearValue(pdfPath) }
+
+  // GENERAL VALUES
   const pdfSchoolData = await processGeneralData(pdfPath)
+
+  // UDISE AND TABLE VALUES
   const tableData = await processTableData(pdfPath)
-  pdfSchoolData.push(tableData)
+
+  pdfSchoolData.push(schoolname, year, tableData)
 
   insertSchoolData(pdfSchoolData)
 

--- a/utils/scraper/processGeneralData.js
+++ b/utils/scraper/processGeneralData.js
@@ -21,8 +21,8 @@ const parseDocument = async pdfPath => {
 }
 
 const extractValue = (data, regexPattern) => {
-  const regex = new RegExp(regexPattern) // create a new regular expression object using the pattern provided
-  const match = regex.exec(data[3]) // regex.exec executes the regular expression regex on the fourth element of the data array
+  const regex = new RegExp(regexPattern)
+  const match = regex.exec(data[3]) 
   if (match && match[1]) {
     return match[1].trim()
   } 
@@ -67,7 +67,6 @@ const processGeneralData = async pdfPath => {
   const year = { year: getYearValue(pdfPath) }
 
   schoolDataArr.push(udise_code, schoolname, year)
-
 
   for (let i = 0; i < all.length; i++) {
     const word = all[i]

--- a/utils/scraper/processGeneralData.js
+++ b/utils/scraper/processGeneralData.js
@@ -68,15 +68,18 @@ const processGeneralData = async pdfPath => {
 
   schoolDataArr.push(udise_code, schoolname, year)
 
+
   for (let i = 0; i < all.length; i++) {
     const word = all[i]
     const value = all[i + 1]
 
     // DIGIBOARD
-    if (word === "DigiBoard" && variablesArr.some(variable => variable.includes(word))) {
+    if (
+      word === "DigiBoard" &&
+      variablesArr.some(variable => variable.includes(word))
+    ) {
       updateSchoolDataArr(word, value, schoolDataArr)
-      return
-    } 
+    } else {
       // ALL OTHER VALUES
       const splitPoint = word.search(/[a-z][A-Z]/)
       let splitWord = word.replace(/[^a-zA-Z0-9\s-/?.()]/g, "")
@@ -85,10 +88,13 @@ const processGeneralData = async pdfPath => {
         splitWord = word.substring(splitPoint + 1)
       }
 
-      if (variablesArr.some(variable => variable.includes(splitWord)) && !variablesArr.includes(value)) {
+      if (
+        variablesArr.some(variable => variable.includes(splitWord)) &&
+        !variablesArr.includes(value)
+      ) {
         updateSchoolDataArr(splitWord, value, schoolDataArr)
       }
-    
+    }
   }
 
   return schoolDataArr

--- a/utils/scraper/processGeneralData.js
+++ b/utils/scraper/processGeneralData.js
@@ -27,22 +27,12 @@ export const getPDFText = async pdfPath => {
   return all
 }
 
-export const getUdiseValue = data => {
-  const regex = new RegExp(/UDISE CODE(.*?)School Name/g)
-  const match = regex.exec(data[3])
-  if (match && match[1]) {
-    return match[1].trim()
-  }
-  return "*"
-}
-
 export const getNameValue = filePath => {
-  console.log(filePath)
   const fileBaseTitle = path
     .basename(filePath)
     .replace(/[.pdf]/g, "")
     .replace(/(2018-19)|(2019-20)|(2020-21)|(2021-22)|(2022-23)_/g, "")
-    .match(/_+(.+)/)
+  .match(/_+(.+)/)
   const schoolName = fileBaseTitle[1].replace(/-/g, " ")
   return schoolName.trim()
 }

--- a/utils/scraper/processGeneralData.js
+++ b/utils/scraper/processGeneralData.js
@@ -24,16 +24,16 @@ export const getPDFText = async pdfPath => {
   const parsedpdf = await parseDocument(pdfPath)
   const pdftext = parsedpdf.text
   const all = pdftext.split("\n")
-  return all 
+  return all
 }
 
 export const getUdiseValue = data => {
   const regex = new RegExp(/UDISE CODE(.*?)School Name/g)
-  const match = regex.exec(data[3]) 
+  const match = regex.exec(data[3])
   if (match && match[1]) {
     return match[1].trim()
-  } 
-    return "*"
+  }
+  return "*"
 }
 
 export const getNameValue = filePath => {
@@ -42,12 +42,10 @@ export const getNameValue = filePath => {
     .basename(filePath)
     .replace(/[.pdf]/g, "")
     .replace(/(2018-19)|(2019-20)|(2020-21)|(2021-22)|(2022-23)_/g, "")
-    // .match(/_+(.+)/)
-    console.log("file base title", fileBaseTitle)
+    .match(/_+(.+)/)
   const schoolName = fileBaseTitle[1].replace(/-/g, " ")
   return schoolName.trim()
 }
-
 
 export const getYearValue = filePath => {
   const yearRegex = /(2018-19)|(2019-20)|(2020-21)|(2021-22)|(2022-23)/
@@ -65,7 +63,6 @@ const updateSchoolDataArr = (word, value, array) => {
 export const processGeneralData = async pdfPath => {
   const schoolDataArr = []
   const all = await getPDFText(pdfPath)
-
 
   for (let i = 0; i < all.length; i++) {
     const word = all[i]
@@ -97,6 +94,3 @@ export const processGeneralData = async pdfPath => {
 
   return schoolDataArr
 }
-
-
-

--- a/utils/scraper/processGeneralData.js
+++ b/utils/scraper/processGeneralData.js
@@ -73,12 +73,10 @@ const processGeneralData = async pdfPath => {
     const value = all[i + 1]
 
     // DIGIBOARD
-    if (
-      word === "DigiBoard" &&
-      variablesArr.some(variable => variable.includes(word))
-    ) {
+    if (word === "DigiBoard" && variablesArr.some(variable => variable.includes(word))) {
       updateSchoolDataArr(word, value, schoolDataArr)
-    } else {
+      return
+    } 
       // ALL OTHER VALUES
       const splitPoint = word.search(/[a-z][A-Z]/)
       let splitWord = word.replace(/[^a-zA-Z0-9\s-/?.()]/g, "")
@@ -87,13 +85,10 @@ const processGeneralData = async pdfPath => {
         splitWord = word.substring(splitPoint + 1)
       }
 
-      if (
-        variablesArr.some(variable => variable.includes(splitWord)) &&
-        !variablesArr.includes(value)
-      ) {
+      if (variablesArr.some(variable => variable.includes(splitWord)) && !variablesArr.includes(value)) {
         updateSchoolDataArr(splitWord, value, schoolDataArr)
       }
-    }
+    
   }
 
   return schoolDataArr

--- a/utils/scraper/processGeneralData.js
+++ b/utils/scraper/processGeneralData.js
@@ -1,6 +1,6 @@
 import { readFileSync } from "fs"
 import path from "path"
-import pdf from "pdf-parse"
+import pdf from "pdf-parse/lib/pdf-parse.js"
 import variables from "./variables.js"
 
 const variablesArr = Object.keys(variables)
@@ -20,8 +20,15 @@ const parseDocument = async pdfPath => {
   }
 }
 
-const extractValue = (data, regexPattern) => {
-  const regex = new RegExp(regexPattern)
+export const getPDFText = async pdfPath => {
+  const parsedpdf = await parseDocument(pdfPath)
+  const pdftext = parsedpdf.text
+  const all = pdftext.split("\n")
+  return all 
+}
+
+export const getUdiseValue = data => {
+  const regex = new RegExp(/UDISE CODE(.*?)School Name/g)
   const match = regex.exec(data[3]) 
   if (match && match[1]) {
     return match[1].trim()
@@ -29,17 +36,20 @@ const extractValue = (data, regexPattern) => {
     return "*"
 }
 
-const getNameValue = filePath => {
+export const getNameValue = filePath => {
+  console.log(filePath)
   const fileBaseTitle = path
     .basename(filePath)
     .replace(/[.pdf]/g, "")
     .replace(/(2018-19)|(2019-20)|(2020-21)|(2021-22)|(2022-23)_/g, "")
-    .match(/_+(.+)/)
+    // .match(/_+(.+)/)
+    console.log("file base title", fileBaseTitle)
   const schoolName = fileBaseTitle[1].replace(/-/g, " ")
   return schoolName.trim()
 }
 
-const getYearValue = filePath => {
+
+export const getYearValue = filePath => {
   const yearRegex = /(2018-19)|(2019-20)|(2020-21)|(2021-22)|(2022-23)/
   const fileBaseTitle = path.basename(filePath)
 
@@ -52,21 +62,10 @@ const updateSchoolDataArr = (word, value, array) => {
   array.push(dataObject)
 }
 
-const processGeneralData = async pdfPath => {
+export const processGeneralData = async pdfPath => {
   const schoolDataArr = []
-  const parsedpdf = await parseDocument(pdfPath)
-  const pdftext = parsedpdf.text
+  const all = await getPDFText(pdfPath)
 
-  const all = pdftext.split("\n")
-
-  // UDISE CODE and SCHOOL NAME and YEAR
-  const udiseRegex = /UDISE CODE(.*?)School Name/g
-
-  const udise_code = { udise_code: extractValue(all, udiseRegex) }
-  const schoolname = { schoolname: getNameValue(pdfPath) }
-  const year = { year: getYearValue(pdfPath) }
-
-  schoolDataArr.push(udise_code, schoolname, year)
 
   for (let i = 0; i < all.length; i++) {
     const word = all[i]
@@ -99,4 +98,5 @@ const processGeneralData = async pdfPath => {
   return schoolDataArr
 }
 
-export default processGeneralData
+
+

--- a/utils/scraper/processGeneralData.js
+++ b/utils/scraper/processGeneralData.js
@@ -47,6 +47,12 @@ const getYearValue = filePath => {
   return fileBaseTitle.match(yearRegex)[0]
 }
 
+const updateSchoolDataArr = (word, value, array) => {
+  const columns = variables[word]
+  const dataObject = { [columns]: value }
+  array.push(dataObject)
+}
+
 const processGeneralData = async pdfPath => {
   const schoolDataArr = []
   const parsedpdf = await parseDocument(pdfPath)
@@ -63,6 +69,7 @@ const processGeneralData = async pdfPath => {
 
   schoolDataArr.push(udise_code, schoolname, year)
 
+
   for (let i = 0; i < all.length; i++) {
     const word = all[i]
     const value = all[i + 1]
@@ -72,9 +79,7 @@ const processGeneralData = async pdfPath => {
       word === "DigiBoard" &&
       variablesArr.some(variable => variable.includes(word))
     ) {
-      const columns = variables[word]
-      const dataObject = { [columns]: value }
-      schoolDataArr.push(dataObject)
+      updateSchoolDataArr(word, value, schoolDataArr )
     } else {
       // ALL OTHER VALUES
       const splitPoint = word.search(/[a-z][A-Z]/)
@@ -88,14 +93,14 @@ const processGeneralData = async pdfPath => {
         variablesArr.some(variable => variable.includes(splitWord)) &&
         !variablesArr.includes(value)
       ) {
-        const columns = variables[splitWord]
-        const dataObject = { [columns]: value }
-        schoolDataArr.push(dataObject)
+        updateSchoolDataArr(splitWord, value, schoolDataArr)
       }
     }
   }
 
   return schoolDataArr
 }
+
+
 
 export default processGeneralData

--- a/utils/scraper/processGeneralData.js
+++ b/utils/scraper/processGeneralData.js
@@ -25,9 +25,8 @@ const extractValue = (data, regexPattern) => {
   const match = regex.exec(data[3]) // regex.exec executes the regular expression regex on the fourth element of the data array
   if (match && match[1]) {
     return match[1].trim()
-  } else {
+  } 
     return "*"
-  }
 }
 
 const getNameValue = filePath => {
@@ -69,7 +68,6 @@ const processGeneralData = async pdfPath => {
 
   schoolDataArr.push(udise_code, schoolname, year)
 
-
   for (let i = 0; i < all.length; i++) {
     const word = all[i]
     const value = all[i + 1]
@@ -79,7 +77,7 @@ const processGeneralData = async pdfPath => {
       word === "DigiBoard" &&
       variablesArr.some(variable => variable.includes(word))
     ) {
-      updateSchoolDataArr(word, value, schoolDataArr )
+      updateSchoolDataArr(word, value, schoolDataArr)
     } else {
       // ALL OTHER VALUES
       const splitPoint = word.search(/[a-z][A-Z]/)
@@ -100,7 +98,5 @@ const processGeneralData = async pdfPath => {
 
   return schoolDataArr
 }
-
-
 
 export default processGeneralData

--- a/utils/scraper/processTableData.js
+++ b/utils/scraper/processTableData.js
@@ -1,12 +1,8 @@
 import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs"
 import { toilets, rte, ews, enrolment_and_minority } from "./coordinates.js"
 
-const parsePage1 = async pdf => {
-  return pdf.getPage(1).then(page => page.getTextContent())
-}
-
-const parsePage2 = async pdf => {
-  return pdf.getPage(2).then(page => page.getTextContent())
+const parsePage = async (pdf, pageNumber) => {
+  return pdf.getPage(pageNumber).then(page => page.getTextContent())
 }
 
 const processColumn = (item, gradeData, grade, row) => {
@@ -96,10 +92,12 @@ const processTableData = async pdf => {
     const loadingTask = getDocument(pdf)
     const pdfDocument = await loadingTask.promise
 
-    const parsedPage1 = await parsePage1(pdfDocument)
-    const parsedPage2 = await parsePage2(pdfDocument)
+    const parsedPage1 = await parsePage(pdfDocument, 1)
+    const parsedPage2 = await parsePage(pdfDocument, 2)
 
     const allTableData = createObject(parsedPage1, parsedPage2)
+
+    console.log(allTableData)
 
     return allTableData
   } catch (err) {

--- a/utils/scraper/processTableData.js
+++ b/utils/scraper/processTableData.js
@@ -71,6 +71,8 @@ const getUdiseValue = async pdf => {
   const match = regex.exec(allText)
   if (match && match[1]) {
     return match[1].trim()
+  } else {
+    return "*"
   }
 }
 

--- a/utils/scraper/processTableData.js
+++ b/utils/scraper/processTableData.js
@@ -70,13 +70,11 @@ const getUdiseValue = async pdf => {
   const regex = new RegExp(/UDISE CODE:? (.*?) ?School Name:?/g)
   const match = regex.exec(allText)
   if (match && match[1]) {
-    return (match[1].trim())
+    return match[1].trim()
   }
 }
 
-
 const createObject = async pdf => {
-  
   const loadingTask = getDocument(pdf)
   const pdfDocument = await loadingTask.promise
   const page1 = await parsePage(pdfDocument, 1)
@@ -109,32 +107,21 @@ const createObject = async pdf => {
     ...en_min_results,
   ]
 
-
   const allTableData = results.reduce((acc, { key, value }) => {
     acc[key] = value
     return acc
   }, {})
 
-
-
-  const udise_code = await getUdiseValue(pdf);
-  allTableData.udise_code = udise_code;
-
-  console.log("allTableData: ", allTableData)
+  const udise_code = await getUdiseValue(pdf)
+  allTableData.udise_code = udise_code
 
   return allTableData
 }
 
-
-// export const udise_code = { udise_code: await getUdiseValue(pdf)}
-
 const processTableData = async pdf => {
   try {
-
-
     const allTableData = createObject(pdf)
     return allTableData
-    
   } catch (err) {
     console.error(`Error: ${err}`)
   }

--- a/utils/scraper/processTableData.js
+++ b/utils/scraper/processTableData.js
@@ -97,8 +97,6 @@ const processTableData = async pdf => {
 
     const allTableData = createObject(parsedPage1, parsedPage2)
 
-    console.log(allTableData)
-
     return allTableData
   } catch (err) {
     console.error(`Error: ${err}`)


### PR DESCRIPTION
Lots of changes in this pr sorry 🙈

- udise code is now being extracted via the ```processTableData()``` function which uses the pdf-dist library - vs. pdf parse in ```processGeneralData()```

Some refactoring (labelled ```tidy: ``` in commit messages):
- extract array data update into resuable function ```updateSchoolDataArr()```
- convert ```extractValue()``` to early return
- remove duplicate ```parsePage()``` functions

When running the single page pdfs through the pdf-dist library the first page text appears - even though we can't view it in our browser or using preview...

Next steps: possibly convert general data to use pdf-dist and get rid of pdf parse entirely (this is potentially quite a big change so not 100% going to go through with it)