### PR TITLE
Pdf js bug

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@ node_modules/
 .env.example
 .env
 *.md
+*.pdf
+school_data.sql

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ npm install
 ```
 
 ## Usage
-The code is designed to be run in four phases:
+The code is designed to be run in five phases:
 - **Crawl** the source page to collect all data endpoints needed 
 - **Download** the base64 files available at each endpoint
 - **Convert** each file to PDF
+- **validateFiles**
 - **Scrape** the data from those files
+
 
 ### Crawling
 `crawler.js` will navigate through all the necessary endpoints to assemble a large json file which can be iterated through by our scraper.
@@ -39,6 +41,10 @@ npm run download
 ```terminal
 npm run convert
 ```
+
+**validateFiles**
+
+Run ```node validateFiles.js``. This will check the files and send all files that don't meet the requirements to corrupted_downloads.
 
 ### Scraper
 *more info soon*

--- a/utils/scraper/processGeneralData.js
+++ b/utils/scraper/processGeneralData.js
@@ -6,7 +6,7 @@ import variables from "./variables.js"
 const variablesArr = Object.keys(variables)
 variablesArr.push("Visit of school for / by")
 
-const parseDocument = async pdfPath => {
+export const parseDocument = async pdfPath => {
   const dataBuffer = readFileSync(pdfPath)
   const options = {
     max: 1,
@@ -16,6 +16,7 @@ const parseDocument = async pdfPath => {
     return pdfdata
   } catch (error) {
     console.error(error)
+    console.log("some error with pdf parse library")
     throw error
   }
 }

--- a/utils/scraper/processTableData.js
+++ b/utils/scraper/processTableData.js
@@ -78,12 +78,6 @@ const getUdiseValue = async pdf => {
 
 const createObject = async pdf => {
   const loadingTask = getDocument(pdf)
-  const testlog = loadingTask._capability.promise
-  try {
-    console.log({ testlog })
-  } catch (error) {
-    console.log("could not be parsed", error)
-  }
   const pdfDocument = await loadingTask.promise
 
   let page1, page2

--- a/utils/scraper/processTableData.js
+++ b/utils/scraper/processTableData.js
@@ -78,6 +78,12 @@ const getUdiseValue = async pdf => {
 
 const createObject = async pdf => {
   const loadingTask = getDocument(pdf)
+  const testlog = loadingTask._capability.promise
+  try {
+    console.log({ testlog })
+  } catch (error) {
+    console.log("could not be parsed", error)
+  }
   const pdfDocument = await loadingTask.promise
 
   let page1, page2

--- a/validateFiles.js
+++ b/validateFiles.js
@@ -10,12 +10,14 @@ const targetFiles = fs.readdirSync(targetFolder)
 
 const pathsList = targetFiles.map(file => path.join(targetFolder, file))
 
+// pdf parse library can identify and catch some errors, but not the ones that break pdf-dist. These files contain no text \n\n and therefore do not break pdf parse. These are now being logged as "corrupted pdf"
+
 const checkPdfContents = async pdfpath => {
-    const pdfdata = await parseDocument(pdfpath)
-    const pdftext = pdfdata.text
-    if (pdftext === '\n\n'){
-        console.log(errorLogColour, "corrupted pdf")
-    } else console.log(bgLogColour, "valid pdf")
+  const pdfdata = await parseDocument(pdfpath)
+  const pdftext = pdfdata.text
+  if (pdftext === "\n\n") {
+    console.log(errorLogColour, "corrupted pdf")
+  } else console.log(bgLogColour, "valid pdf")
 }
 
 // checkPdfContents('/Users/eazzopardi/code/agency/agency-scraper/1203410_2022-23_LAYALPUR-KHALSA-COLLEGIATE-SEN.SEC-SCHOOL.pdf') // broken pdf
@@ -31,12 +33,10 @@ const validateFiles = async () => {
   for (let index = 0; index < pathsList.length; index++) {
     if (!pathsList[index].includes(".DS_Store")) {
       try {
-        await
-          checkPdfContents(pathsList[index])
-          totalProcessed++
-          console.log(totalProcessed)
-        }
-        catch (error) {
+        await checkPdfContents(pathsList[index])
+        totalProcessed++
+        console.log(totalProcessed)
+      } catch (error) {
         console.error(
           errorLogColour,
           `Error scraping ${pathsList[index]}: ${error}`,
@@ -47,5 +47,6 @@ const validateFiles = async () => {
 
   console.log(bgLogColour, `${totalProcessed} files validated`)
 }
+
 
 validateFiles()

--- a/validateFiles.js
+++ b/validateFiles.js
@@ -1,0 +1,51 @@
+import path from "path"
+import fs from "fs"
+
+import { parseDocument } from "./utils/scraper/processGeneralData.js"
+import { bgLogColour, errorLogColour } from "./utils/colours.js"
+
+const __dirname = new URL(".", import.meta.url).pathname
+const targetFolder = path.resolve(__dirname, "./utils/converter/downloads")
+const targetFiles = fs.readdirSync(targetFolder)
+
+const pathsList = targetFiles.map(file => path.join(targetFolder, file))
+
+const checkPdfContents = async pdfpath => {
+    const pdfdata = await parseDocument(pdfpath)
+    const pdftext = pdfdata.text
+    if (pdftext === '\n\n'){
+        console.log(errorLogColour, "corrupted pdf")
+    } else console.log(bgLogColour, "valid pdf")
+}
+
+// checkPdfContents('/Users/eazzopardi/code/agency/agency-scraper/1203410_2022-23_LAYALPUR-KHALSA-COLLEGIATE-SEN.SEC-SCHOOL.pdf') // broken pdf
+
+const validateFiles = async () => {
+  if (pathsList.length === 0) {
+    console.log(errorLogColour, "No files available to validate")
+    return
+  }
+
+  let totalProcessed = 0
+
+  for (let index = 0; index < pathsList.length; index++) {
+    if (!pathsList[index].includes(".DS_Store")) {
+      try {
+        await
+          checkPdfContents(pathsList[index])
+          totalProcessed++
+          console.log(totalProcessed)
+        }
+        catch (error) {
+        console.error(
+          errorLogColour,
+          `Error scraping ${pathsList[index]}: ${error}`,
+        )
+      }
+    }
+  }
+
+  console.log(bgLogColour, `${totalProcessed} files validated`)
+}
+
+validateFiles()

--- a/validateFiles.js
+++ b/validateFiles.js
@@ -8,9 +8,14 @@ const __dirname = new URL(".", import.meta.url).pathname
 
 const originalFolder = path.resolve(__dirname, "./utils/converter/downloads")
 const originalFiles = fs.readdirSync(originalFolder)
-const originalPathsList = originalFiles.map(file => path.join(originalFolder, file))
+const originalPathsList = originalFiles.map(file =>
+  path.join(originalFolder, file),
+)
 
-const targetFolder = path.resolve(__dirname, "./utils/converter/corrupted_downloads")
+const targetFolder = path.resolve(
+  __dirname,
+  "./utils/converter/corrupted_downloads",
+)
 
 const checkPdfContents = async pdfpath => {
   const pdfdata = await parseDocument(pdfpath)
@@ -20,20 +25,25 @@ const checkPdfContents = async pdfpath => {
     console.log(corruptedFilePath)
     console.log(errorLogColour, "corrupted pdf")
     fs.renameSync(pdfpath, corruptedFilePath)
-    } else {
-        console.log(bgLogColour, "valid pdf")
-    }
+  } else {
+    console.log(bgLogColour, "valid pdf")
+  }
 }
 
 const validateFiles = async () => {
-    const corrupted_downloadsDir = path.join(__dirname, "utils", "converter", "corrupted_downloads")
-    if (!fs.existsSync(corrupted_downloadsDir)) {
+  const corrupted_downloadsDir = path.join(
+    __dirname,
+    "utils",
+    "converter",
+    "corrupted_downloads",
+  )
+  if (!fs.existsSync(corrupted_downloadsDir)) {
     fs.mkdirSync(corrupted_downloadsDir)
-    }
-    if (originalPathsList.length === 0) {
-        console.log(errorLogColour, "No files available to validate")
-        return
-    }
+  }
+  if (originalPathsList.length === 0) {
+    console.log(errorLogColour, "No files available to validate")
+    return
+  }
 
   let totalProcessed = 0
 


### PR DESCRIPTION
- create ValidateFiles functions checks pdf text content is not empty.
- If pdf empty (no text content), pdf is sent to corrupted_downloads folder.
- A couple of changes to the .prettierignore to ignore corrupted_downloads and the school_data database which is now on my local